### PR TITLE
test_hier_clusters_exact pass dist argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: Clusters observations, then tests whether there
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Suggests: 
     graphics
 Imports: 

--- a/R/trunc_inf.R
+++ b/R/trunc_inf.R
@@ -32,7 +32,7 @@
 #' @param iso Boolean. If \code{TRUE}, isotropic covariance matrix model, otherwise not.
 #' @param sig Optional scalar specifying \eqn{\sigma}, relevant if \code{iso} is \code{TRUE}.
 #' @param SigInv Optional matrix specifying \eqn{\Sigma^{-1}}, relevant if \code{iso} is \code{FALSE}.
-#'
+#' @param dist The distances of matrix X
 #' @return
 #' \item{stat}{the test statistic: the Euclidean distance between the mean of cluster \code{k1} and the mean of cluster \code{k2}  }
 #' \item{pval}{the p-value}
@@ -62,7 +62,7 @@
 #' \code{\link{test_clusters_approx}} for approximate p-values for a user-specified clustering function;
 #' 
 #' @references Lucy L. Gao et al. "Selective inference for hierarchical clustering". 
-test_hier_clusters_exact <- function(X, link, hcl, K, k1, k2, iso=TRUE, sig=NULL, SigInv=NULL) {
+test_hier_clusters_exact <- function(X, link, hcl, K, k1, k2, iso=TRUE, sig=NULL, SigInv=NULL, dist=NULL) {
     # error checking 
     if(!is.matrix(X)) stop("X should be a matrix")
   
@@ -82,7 +82,9 @@ test_hier_clusters_exact <- function(X, link, hcl, K, k1, k2, iso=TRUE, sig=NULL
     n2 <- sum(hcl_at_K == k2)
     squared_norm_nu <- 1/n1 + 1/n2
     diff_means <- colMeans(X[hcl_at_K == k1, , drop=FALSE]) - colMeans(X[hcl_at_K == k2, , drop=FALSE])
-
+    
+    if(is.null(dist)) dist <- stats::dist(X)^2
+    
     if(iso) {
       if(is.null(sig)) {
         sig <- sqrt(sum(scale(X, scale=FALSE)^2)/(n*q - q))
@@ -92,12 +94,12 @@ test_hier_clusters_exact <- function(X, link, hcl, K, k1, k2, iso=TRUE, sig=NULL
       stat <- norm_vec(diff_means)
 
       # compute truncation set
-      if(link == "single") S <- compute_S_single(X, hcl, K, k1, k2)
-      if(link == "average") S <- compute_S_average(X, hcl, K, k1, k2)
-      if(link == "centroid") S <-  compute_S_centroid(X, hcl, K, k1, k2)
-      if(link == "ward.D") S <-  compute_S_ward(X, hcl, K, k1, k2)
-      if(link == "mcquitty") S <-  compute_S_mcquitty(X, hcl, K, k1, k2)
-      if(link == "median") S <-  compute_S_median(X, hcl, K, k1, k2)
+      if(link == "single") S <- compute_S_single(X, hcl, K, k1, k2, dist)
+      if(link == "average") S <- compute_S_average(X, hcl, K, k1, k2, dist)
+      if(link == "centroid") S <-  compute_S_centroid(X, hcl, K, k1, k2, dist)
+      if(link == "ward.D") S <-  compute_S_ward(X, hcl, K, k1, k2, dist)
+      if(link == "mcquitty") S <-  compute_S_mcquitty(X, hcl, K, k1, k2, dist)
+      if(link == "median") S <-  compute_S_median(X, hcl, K, k1, k2, dist)
 
       # set distribution of phi
       scale_factor <- squared_norm_nu*sig^2
@@ -113,11 +115,11 @@ test_hier_clusters_exact <- function(X, link, hcl, K, k1, k2, iso=TRUE, sig=NULL
 
       # compute truncation set
       if(link == "single") S <- compute_S_single_gencov(X, hcl, K, k1, k2, stat)
-      if(link == "average") S <- compute_S_average_gencov(X, hcl, K, k1, k2, stat)
-      if(link == "centroid") S <-  compute_S_centroid_gencov(X, hcl, K, k1, k2, stat)
-      if(link == "ward.D") S <-  compute_S_ward_gencov(X, hcl, K, k1, k2, stat)
-      if(link == "mcquitty") S <-  compute_S_mcquitty_gencov(X, hcl, K, k1, k2, stat)
-      if(link == "median") S <-  compute_S_median_gencov(X, hcl, K, k1, k2, stat)
+      if(link == "average") S <- compute_S_average_gencov(X, hcl, K, k1, k2, stat, dist)
+      if(link == "centroid") S <-  compute_S_centroid_gencov(X, hcl, K, k1, k2, stat, dist)
+      if(link == "ward.D") S <-  compute_S_ward_gencov(X, hcl, K, k1, k2, stat, dist)
+      if(link == "mcquitty") S <-  compute_S_mcquitty_gencov(X, hcl, K, k1, k2, stat, dist)
+      if(link == "median") S <-  compute_S_median_gencov(X, hcl, K, k1, k2, stat, dist)
 
       # set distribution of phi
       scale_factor <- squared_norm_nu

--- a/R/trunc_sets.R
+++ b/R/trunc_sets.R
@@ -102,11 +102,12 @@ solve_one_ineq <- function(A, B, C, tol=1e-10) {
 #' @param K number of clusters
 #' @param k1 the index of first cluster involved in the test
 #' @param k2 the index of second cluster involved in the test
+#' @param dist The distances of matrix X
 #'
 #' @keywords internal
 #'
 #' @return Returns an "Intervals" object containing the conditioning set.
-compute_S_single <- function(X, hcl, K, k1, k2) {
+compute_S_single <- function(X, hcl, K, k1, k2, dist) {
   # Initialization and book-keeping 
   n <- nrow(X)
   h <- hcl$height[n-K] 
@@ -189,11 +190,12 @@ compute_S_single <- function(X, hcl, K, k1, k2) {
 #' @param K number of clusters
 #' @param k1 the index of first cluster involved in the test
 #' @param k2 the index of second cluster involved in the test
+#' @param dist The distances of matrix X
 #'
 #' @keywords internal
 #'
 #' @return Returns an "Intervals" object containing the conditioning set.
-compute_S_average <- function(X, hcl, K, k1, k2) {
+compute_S_average <- function(X, hcl, K, k1, k2, dist) {
   # Initialization and book-keeping 
   n <- nrow(X)
   heights <- hcl$height 
@@ -221,7 +223,7 @@ compute_S_average <- function(X, hcl, K, k1, k2) {
   # Make the coefficients for d(i, i'; x'(\phi))
   B <- matrix(NA, nrow(X), nrow(X))
   C <- matrix(NA, nrow(X), nrow(X))
-  C[lower.tri(C)] <- stats::dist(X)^2
+  C[lower.tri(C)] <- dist
   
   # compute quantities used in all coefficients
   prop_k2 <- length(k2_obs)/(length(k1_obs) + length(k2_obs))
@@ -575,11 +577,12 @@ compute_S_average <- function(X, hcl, K, k1, k2) {
 #' @param K number of clusters
 #' @param k1 the index of first cluster involved in the test
 #' @param k2 the index of second cluster involved in the test
+#' @param dist The distances of matrix X
 #'
 #' @keywords internal
 #'
 #' @return Returns an "Intervals" object containing the conditioning set.
-compute_S_centroid <- function(X, hcl, K, k1, k2) {
+compute_S_centroid <- function(X, hcl, K, k1, k2, dist) {
   n <- nrow(X)
   heights <- hcl$height 
   merges <- hcl$merge
@@ -610,7 +613,7 @@ compute_S_centroid <- function(X, hcl, K, k1, k2) {
   # Make the coefficients for d(i, i'; x'(\phi))
   B <- matrix(NA, nrow(X), nrow(X))
   C <- matrix(NA, nrow(X), nrow(X))
-  C[lower.tri(C)] <- stats::dist(X)^2
+  C[lower.tri(C)] <- dist
   
   # compute quantities used in all coefficients
   prop_k2 <- length(k2_obs)/(length(k1_obs) + length(k2_obs))
@@ -1062,11 +1065,12 @@ compute_S_centroid <- function(X, hcl, K, k1, k2) {
 #' @param K number of clusters
 #' @param k1 the index of first cluster involved in the test
 #' @param k2 the index of second cluster involved in the test
+#' @param dist The distances of matrix X
 #'
 #' @keywords internal
 #'
 #' @return Returns an "Intervals" object containing the conditioning set.
-compute_S_ward <- function(X, hcl, K, k1, k2) { 
+compute_S_ward <- function(X, hcl, K, k1, k2, dist) { 
   # Initialization and book-keeping 
   n <- nrow(X)
   heights <- hcl$height 
@@ -1095,7 +1099,7 @@ compute_S_ward <- function(X, hcl, K, k1, k2) {
   A <- matrix(NA, nrow(X), nrow(X))
   B <- matrix(NA, nrow(X), nrow(X))
   C <- matrix(NA, nrow(X), nrow(X))
-  C[lower.tri(C)] <- stats::dist(X)^2
+  C[lower.tri(C)] <- dist
   
   # compute quantities used in all coefficients
   prop_k2 <- length(k2_obs)/(length(k1_obs) + length(k2_obs))
@@ -1457,11 +1461,12 @@ compute_S_ward <- function(X, hcl, K, k1, k2) {
 #' @param K number of clusters
 #' @param k1 the index of first cluster involved in the test
 #' @param k2 the index of second cluster involved in the test
+#' @param dist The distances of matrix X
 #'
 #' @keywords internal
 #'
 #' @return Returns an "Intervals" object containing the conditioning set.
-compute_S_mcquitty <- function(X, hcl, K, k1, k2) {
+compute_S_mcquitty <- function(X, hcl, K, k1, k2, dist) {
   # Initialization and book-keeping 
   n <- nrow(X)
   heights <- hcl$height 
@@ -1489,7 +1494,7 @@ compute_S_mcquitty <- function(X, hcl, K, k1, k2) {
   # Make the coefficients for d(i, i'; x'(\phi))
   B <- matrix(NA, nrow(X), nrow(X))
   C <- matrix(NA, nrow(X), nrow(X))
-  C[lower.tri(C)] <- stats::dist(X)^2
+  C[lower.tri(C)] <- dist
   
   # compute quantities used in all coefficients
   prop_k2 <- length(k2_obs)/(length(k1_obs) + length(k2_obs))
@@ -1840,11 +1845,12 @@ compute_S_mcquitty <- function(X, hcl, K, k1, k2) {
 #' @param K number of clusters
 #' @param k1 the index of first cluster involved in the test
 #' @param k2 the index of second cluster involved in the test
+#' @param dist The distances of matrix X
 #'
 #' @keywords internal
 #'
 #' @return Returns an "Intervals" object containing the conditioning set.
-compute_S_median <- function(X, hcl, K, k1, k2) {
+compute_S_median <- function(X, hcl, K, k1, k2, dist) {
   n <- nrow(X)
   heights <- hcl$height 
   merges <- hcl$merge
@@ -1875,7 +1881,7 @@ compute_S_median <- function(X, hcl, K, k1, k2) {
   # Make the coefficients for d(i, i'; x'(\phi))
   B <- matrix(NA, nrow(X), nrow(X))
   C <- matrix(NA, nrow(X), nrow(X))
-  C[lower.tri(C)] <- stats::dist(X)^2
+  C[lower.tri(C)] <- dist
   
   # compute quantities used in all coefficients
   prop_k2 <- length(k2_obs)/(length(k1_obs) + length(k2_obs))
@@ -2425,11 +2431,12 @@ compute_S_single_gencov <- function(X, hcl, K, k1, k2, stat) {
 #' @param k1 the index of first cluster involved in the test
 #' @param k2 the index of second cluster involved in the test
 #' @param stat the test statistic, \eqn{||\Sigma^{-1/2} x^T \nu||_2}
+#' @param dist The distances of matrix X
 #'
 #' @keywords internal
 #'
 #' @return Returns an "Intervals" object containing the conditioning set.
-compute_S_average_gencov <- function(X, hcl, K, k1, k2, stat) { 
+compute_S_average_gencov <- function(X, hcl, K, k1, k2, stat, dist) { 
   # Initialization and book-keeping 
   n <- nrow(X)
   heights <- hcl$height 
@@ -2457,7 +2464,7 @@ compute_S_average_gencov <- function(X, hcl, K, k1, k2, stat) {
   # Make the coefficients for d(i, i'; x'(\phi))
   B <- matrix(NA, nrow(X), nrow(X))
   C <- matrix(NA, nrow(X), nrow(X))
-  C[lower.tri(C)] <- stats::dist(X)^2
+  C[lower.tri(C)] <- dist
   
   # compute quantities used in all coefficients
   prop_k2 <- length(k2_obs)/(length(k1_obs) + length(k2_obs))
@@ -2818,11 +2825,12 @@ compute_S_average_gencov <- function(X, hcl, K, k1, k2, stat) {
 #' @param k1 the index of first cluster involved in the test
 #' @param k2 the index of second cluster involved in the test
 #' @param stat the test statistic, \eqn{||\Sigma^{-1/2} x^T \nu||_2}
+#' @param dist The distances of matrix X
 #'
 #' @keywords internal
 #'
 #' @return Returns an "Intervals" object containing the conditioning set.
-compute_S_centroid_gencov <- function(X, hcl, K, k1, k2, stat) { 
+compute_S_centroid_gencov <- function(X, hcl, K, k1, k2, stat, dist) { 
   # Initialization and book-keeping 
   n <- nrow(X)
   heights <- hcl$height 
@@ -2850,7 +2858,7 @@ compute_S_centroid_gencov <- function(X, hcl, K, k1, k2, stat) {
   # Make the coefficients for d(i, i'; x'(\phi))
   B <- matrix(NA, nrow(X), nrow(X))
   C <- matrix(NA, nrow(X), nrow(X))
-  C[lower.tri(C)] <- stats::dist(X)^2
+  C[lower.tri(C)] <- dist
   
   # compute quantities used in all coefficients
   prop_k2 <- length(k2_obs)/(length(k1_obs) + length(k2_obs))
@@ -3201,11 +3209,12 @@ compute_S_centroid_gencov <- function(X, hcl, K, k1, k2, stat) {
 #' @param k1 the index of first cluster involved in the test
 #' @param k2 the index of second cluster involved in the test
 #' @param stat the test statistic, \eqn{||\Sigma^{-1/2} x^T \nu||_2}
+#' @param dist The distances of matrix X
 #'
 #' @keywords internal
 #'
 #' @return Returns an "Intervals" object containing the conditioning set.
-compute_S_ward_gencov <- function(X, hcl, K, k1, k2, stat) { 
+compute_S_ward_gencov <- function(X, hcl, K, k1, k2, stat, dist) { 
   # Initialization and book-keeping 
   n <- nrow(X)
   heights <- hcl$height 
@@ -3234,7 +3243,7 @@ compute_S_ward_gencov <- function(X, hcl, K, k1, k2, stat) {
   A <- matrix(NA, nrow(X), nrow(X))
   B <- matrix(NA, nrow(X), nrow(X))
   C <- matrix(NA, nrow(X), nrow(X))
-  C[lower.tri(C)] <- stats::dist(X)^2
+  C[lower.tri(C)] <- dist
   
   # compute quantities used in all coefficients
   prop_k2 <- length(k2_obs)/(length(k1_obs) + length(k2_obs))
@@ -3602,11 +3611,12 @@ compute_S_ward_gencov <- function(X, hcl, K, k1, k2, stat) {
 #' @param k1 the index of first cluster involved in the test
 #' @param k2 the index of second cluster involved in the test
 #' @param stat the test statistic, \eqn{||\Sigma^{-1/2} x^T \nu||_2}
+#' @param dist The distances of matrix X
 #'
 #' @keywords internal
 #'
 #' @return Returns an "Intervals" object containing the conditioning set.
-compute_S_mcquitty_gencov <- function(X, hcl, K, k1, k2, stat) { 
+compute_S_mcquitty_gencov <- function(X, hcl, K, k1, k2, stat, dist) { 
   # Initialization and book-keeping 
   n <- nrow(X)
   heights <- hcl$height 
@@ -3634,7 +3644,7 @@ compute_S_mcquitty_gencov <- function(X, hcl, K, k1, k2, stat) {
   # Make the coefficients for d(i, i'; x'(\phi))
   B <- matrix(NA, nrow(X), nrow(X))
   C <- matrix(NA, nrow(X), nrow(X))
-  C[lower.tri(C)] <- stats::dist(X)^2
+  C[lower.tri(C)] <- dist
   
   # compute quantities used in all coefficients
   prop_k2 <- length(k2_obs)/(length(k1_obs) + length(k2_obs))
@@ -3994,11 +4004,12 @@ compute_S_mcquitty_gencov <- function(X, hcl, K, k1, k2, stat) {
 #' @param k1 the index of first cluster involved in the test
 #' @param k2 the index of second cluster involved in the test
 #' @param stat the test statistic, \eqn{||\Sigma^{-1/2} x^T \nu||_2}
+#' @param dist The distances of matrix X
 #'
 #' @keywords internal
 #'
 #' @return Returns an "Intervals" object containing the conditioning set.
-compute_S_median_gencov <- function(X, hcl, K, k1, k2, stat) { 
+compute_S_median_gencov <- function(X, hcl, K, k1, k2, stat, dist) { 
   # Initialization and book-keeping 
   n <- nrow(X)
   heights <- hcl$height 
@@ -4026,7 +4037,7 @@ compute_S_median_gencov <- function(X, hcl, K, k1, k2, stat) {
   # Make the coefficients for d(i, i'; x'(\phi))
   B <- matrix(NA, nrow(X), nrow(X))
   C <- matrix(NA, nrow(X), nrow(X))
-  C[lower.tri(C)] <- stats::dist(X)^2
+  C[lower.tri(C)] <- dist
   
   # compute quantities used in all coefficients
   prop_k2 <- length(k2_obs)/(length(k1_obs) + length(k2_obs))

--- a/man/compute_S_average.Rd
+++ b/man/compute_S_average.Rd
@@ -4,7 +4,7 @@
 \alias{compute_S_average}
 \title{Computes the conditioning set for average linkage hierarchical clustering}
 \usage{
-compute_S_average(X, hcl, K, k1, k2)
+compute_S_average(X, hcl, K, k1, k2, dist)
 }
 \arguments{
 \item{X}{the n x q data set}
@@ -16,6 +16,8 @@ compute_S_average(X, hcl, K, k1, k2)
 \item{k1}{the index of first cluster involved in the test}
 
 \item{k2}{the index of second cluster involved in the test}
+
+\item{dist}{The distances of matrix X}
 }
 \value{
 Returns an "Intervals" object containing the conditioning set.

--- a/man/compute_S_average_gencov.Rd
+++ b/man/compute_S_average_gencov.Rd
@@ -5,7 +5,7 @@
 \title{Computes the conditioning set S for average linkage hierarchical clustering,
 w/o assuming isotropic covariance matrix}
 \usage{
-compute_S_average_gencov(X, hcl, K, k1, k2, stat)
+compute_S_average_gencov(X, hcl, K, k1, k2, stat, dist)
 }
 \arguments{
 \item{X}{the n x q data set}
@@ -19,6 +19,8 @@ compute_S_average_gencov(X, hcl, K, k1, k2, stat)
 \item{k2}{the index of second cluster involved in the test}
 
 \item{stat}{the test statistic, \eqn{||\Sigma^{-1/2} x^T \nu||_2}}
+
+\item{dist}{The distances of matrix X}
 }
 \value{
 Returns an "Intervals" object containing the conditioning set.

--- a/man/compute_S_centroid.Rd
+++ b/man/compute_S_centroid.Rd
@@ -4,7 +4,7 @@
 \alias{compute_S_centroid}
 \title{Computes the conditioning set for centroid linkage hierarchical clustering}
 \usage{
-compute_S_centroid(X, hcl, K, k1, k2)
+compute_S_centroid(X, hcl, K, k1, k2, dist)
 }
 \arguments{
 \item{X}{the n x q data set}
@@ -16,6 +16,8 @@ compute_S_centroid(X, hcl, K, k1, k2)
 \item{k1}{the index of first cluster involved in the test}
 
 \item{k2}{the index of second cluster involved in the test}
+
+\item{dist}{The distances of matrix X}
 }
 \value{
 Returns an "Intervals" object containing the conditioning set.

--- a/man/compute_S_centroid_gencov.Rd
+++ b/man/compute_S_centroid_gencov.Rd
@@ -5,7 +5,7 @@
 \title{Computes the conditioning set S for centroid linkage hierarchical clustering,
 w/o assuming isotropic covariance matrix}
 \usage{
-compute_S_centroid_gencov(X, hcl, K, k1, k2, stat)
+compute_S_centroid_gencov(X, hcl, K, k1, k2, stat, dist)
 }
 \arguments{
 \item{X}{the n x q data set}
@@ -19,6 +19,8 @@ compute_S_centroid_gencov(X, hcl, K, k1, k2, stat)
 \item{k2}{the index of second cluster involved in the test}
 
 \item{stat}{the test statistic, \eqn{||\Sigma^{-1/2} x^T \nu||_2}}
+
+\item{dist}{The distances of matrix X}
 }
 \value{
 Returns an "Intervals" object containing the conditioning set.

--- a/man/compute_S_mcquitty.Rd
+++ b/man/compute_S_mcquitty.Rd
@@ -4,7 +4,7 @@
 \alias{compute_S_mcquitty}
 \title{Computes the conditioning set for McQuitty linkage hierarchical clustering (WPGMA)}
 \usage{
-compute_S_mcquitty(X, hcl, K, k1, k2)
+compute_S_mcquitty(X, hcl, K, k1, k2, dist)
 }
 \arguments{
 \item{X}{the n x q data set}
@@ -16,6 +16,8 @@ compute_S_mcquitty(X, hcl, K, k1, k2)
 \item{k1}{the index of first cluster involved in the test}
 
 \item{k2}{the index of second cluster involved in the test}
+
+\item{dist}{The distances of matrix X}
 }
 \value{
 Returns an "Intervals" object containing the conditioning set.

--- a/man/compute_S_mcquitty_gencov.Rd
+++ b/man/compute_S_mcquitty_gencov.Rd
@@ -5,7 +5,7 @@
 \title{Computes the conditioning set S for McQuitty linkage hierarchical clustering (WPGMA),
 w/o assuming isotropic covariance matrix}
 \usage{
-compute_S_mcquitty_gencov(X, hcl, K, k1, k2, stat)
+compute_S_mcquitty_gencov(X, hcl, K, k1, k2, stat, dist)
 }
 \arguments{
 \item{X}{the n x q data set}
@@ -19,6 +19,8 @@ compute_S_mcquitty_gencov(X, hcl, K, k1, k2, stat)
 \item{k2}{the index of second cluster involved in the test}
 
 \item{stat}{the test statistic, \eqn{||\Sigma^{-1/2} x^T \nu||_2}}
+
+\item{dist}{The distances of matrix X}
 }
 \value{
 Returns an "Intervals" object containing the conditioning set.

--- a/man/compute_S_median.Rd
+++ b/man/compute_S_median.Rd
@@ -4,7 +4,7 @@
 \alias{compute_S_median}
 \title{Computes the conditioning set for median linkage hierarchical clustering (WPGMC)}
 \usage{
-compute_S_median(X, hcl, K, k1, k2)
+compute_S_median(X, hcl, K, k1, k2, dist)
 }
 \arguments{
 \item{X}{the n x q data set}
@@ -16,6 +16,8 @@ compute_S_median(X, hcl, K, k1, k2)
 \item{k1}{the index of first cluster involved in the test}
 
 \item{k2}{the index of second cluster involved in the test}
+
+\item{dist}{The distances of matrix X}
 }
 \value{
 Returns an "Intervals" object containing the conditioning set.

--- a/man/compute_S_median_gencov.Rd
+++ b/man/compute_S_median_gencov.Rd
@@ -5,7 +5,7 @@
 \title{Computes the conditioning set S for median linkage hierarchical clustering (WPGMC),
 w/o assuming isotropic covariance matrix}
 \usage{
-compute_S_median_gencov(X, hcl, K, k1, k2, stat)
+compute_S_median_gencov(X, hcl, K, k1, k2, stat, dist)
 }
 \arguments{
 \item{X}{the n x q data set}
@@ -19,6 +19,8 @@ compute_S_median_gencov(X, hcl, K, k1, k2, stat)
 \item{k2}{the index of second cluster involved in the test}
 
 \item{stat}{the test statistic, \eqn{||\Sigma^{-1/2} x^T \nu||_2}}
+
+\item{dist}{The distances of matrix X}
 }
 \value{
 Returns an "Intervals" object containing the conditioning set.

--- a/man/compute_S_single.Rd
+++ b/man/compute_S_single.Rd
@@ -4,7 +4,7 @@
 \alias{compute_S_single}
 \title{Computes the conditioning set for single linkage hierarchical clustering}
 \usage{
-compute_S_single(X, hcl, K, k1, k2)
+compute_S_single(X, hcl, K, k1, k2, dist)
 }
 \arguments{
 \item{X}{the n x q data set}
@@ -16,6 +16,8 @@ compute_S_single(X, hcl, K, k1, k2)
 \item{k1}{the index of first cluster involved in the test}
 
 \item{k2}{the index of second cluster involved in the test}
+
+\item{dist}{The distances of matrix X}
 }
 \value{
 Returns an "Intervals" object containing the conditioning set.

--- a/man/compute_S_ward.Rd
+++ b/man/compute_S_ward.Rd
@@ -4,7 +4,7 @@
 \alias{compute_S_ward}
 \title{Computes the conditioning set for Ward linkage hierarchical clustering}
 \usage{
-compute_S_ward(X, hcl, K, k1, k2)
+compute_S_ward(X, hcl, K, k1, k2, dist)
 }
 \arguments{
 \item{X}{the n x q data set}
@@ -16,6 +16,8 @@ compute_S_ward(X, hcl, K, k1, k2)
 \item{k1}{the index of first cluster involved in the test}
 
 \item{k2}{the index of second cluster involved in the test}
+
+\item{dist}{The distances of matrix X}
 }
 \value{
 Returns an "Intervals" object containing the conditioning set.

--- a/man/compute_S_ward_gencov.Rd
+++ b/man/compute_S_ward_gencov.Rd
@@ -5,7 +5,7 @@
 \title{Computes the conditioning set S for ward linkage hierarchical clustering,
 w/o assuming isotropic covariance matrix}
 \usage{
-compute_S_ward_gencov(X, hcl, K, k1, k2, stat)
+compute_S_ward_gencov(X, hcl, K, k1, k2, stat, dist)
 }
 \arguments{
 \item{X}{the n x q data set}
@@ -19,6 +19,8 @@ compute_S_ward_gencov(X, hcl, K, k1, k2, stat)
 \item{k2}{the index of second cluster involved in the test}
 
 \item{stat}{the test statistic, \eqn{||\Sigma^{-1/2} x^T \nu||_2}}
+
+\item{dist}{The distances of matrix X}
 }
 \value{
 Returns an "Intervals" object containing the conditioning set.

--- a/man/test_hier_clusters_exact.Rd
+++ b/man/test_hier_clusters_exact.Rd
@@ -13,7 +13,8 @@ test_hier_clusters_exact(
   k2,
   iso = TRUE,
   sig = NULL,
-  SigInv = NULL
+  SigInv = NULL,
+  dist = NULL
 )
 }
 \arguments{
@@ -33,6 +34,8 @@ test_hier_clusters_exact(
 \item{sig}{Optional scalar specifying \eqn{\sigma}, relevant if \code{iso} is \code{TRUE}.}
 
 \item{SigInv}{Optional matrix specifying \eqn{\Sigma^{-1}}, relevant if \code{iso} is \code{FALSE}.}
+
+\item{dist}{The distances of matrix X}
 }
 \value{
 \item{stat}{the test statistic: the Euclidean distance between the mean of cluster \code{k1} and the mean of cluster \code{k2}  }


### PR DESCRIPTION
Hi Lucy, here is a PR suggestion, but feel free to opt for other implementations.

- Addresses #6 
- Introduces `dist` argument to `test_hier_clusters_exact`
- For compatibility, if no `dist` argument is passed, distances are computed as in previous versions using `stats::dist(X)^2` 
- Documentation has been rebuilt to reflect these changes

A brief benchmark on an i7 laptop:
- on 1000 x 1000 matrix runtime decreased from ~17 s to ~ 11 s. 
- on a smaller, 1000 x 100 matrix, runtime decreased from ~4.1 s to ~3.7 s

It's clear that this will mostly benefit large-scale analysis, but there it could be very helpful (I sometimes run this on a scale where it takes ~ 1 h to cluster my data and compute p-values, so a 30-40% speedup makes a large difference there).

I'm sure there is still room for further speedups, but this was a nice low-hanging fruit. Let me know what you think!

Cheers,
Jesko