### PR TITLE
Add helper functions to calculate log(gamma(q/2)) without overflowing float

### DIFF
--- a/R/trunc_inf.R
+++ b/R/trunc_inf.R
@@ -275,7 +275,8 @@ test_complete_hier_clusters_approx <- function(X, hcl, K, k1, k2, iso=TRUE, sig=
     hcl_Xphi <- fastcluster::hclust(stats::dist(Xphi)^2, method="complete")
     clusters_Xphi <- stats::cutree(hcl_Xphi, K)
     if(same_cl(hcl_at_K, clusters_Xphi, K)) {
-      log_survives[j] <- -(phi[j]/scale_factor)^2/2 + (q-1)*log(phi[j]/scale_factor) - (q/2 - 1)*log(2) - log(gamma(q/2)) - log(scale_factor) -
+      log_gamma_q_over_2 = calculate_log_gamma_q_over_2(q)
+      log_survives[j] <- -(phi[j]/scale_factor)^2/2 + (q-1)*log(phi[j]/scale_factor) - (q/2 - 1)*log(2) - log_gamma_q_over_2 - log(scale_factor) -
         stats::dnorm(phi[j], mean=stat, sd=scale_factor, log=TRUE)
     }
   }
@@ -423,7 +424,8 @@ test_clusters_approx <- function(X, k1, k2, iso=TRUE, sig=NULL, SigInv=NULL, ndr
     # Recluster the perturbed data set
     cl_Xphi <- cl_fun(Xphi)
     if(preserve_cl(cl, cl_Xphi, k1, k2)) {
-      log_survives <- -(phi[j]/scale_factor)^2/2 + (q-1)*log(phi[j]/scale_factor) - (q/2 - 1)*log(2) - log(gamma(q/2)) - log(scale_factor) -
+      log_gamma_q_over_2 = calculate_log_gamma_q_over_2(q)
+      log_survives <- -(phi[j]/scale_factor)^2/2 + (q-1)*log(phi[j]/scale_factor) - (q/2 - 1)*log(2) - log_gamma_q_over_2 - log(scale_factor) -
         stats::dnorm(phi[j], mean=stat, sd=scale_factor, log=TRUE)
       return(log_survives)
     }

--- a/R/trunc_inf.R
+++ b/R/trunc_inf.R
@@ -275,7 +275,7 @@ test_complete_hier_clusters_approx <- function(X, hcl, K, k1, k2, iso=TRUE, sig=
     hcl_Xphi <- fastcluster::hclust(stats::dist(Xphi)^2, method="complete")
     clusters_Xphi <- stats::cutree(hcl_Xphi, K)
     if(same_cl(hcl_at_K, clusters_Xphi, K)) {
-      log_gamma_q_over_2 = calculate_log_gamma_q_over_2(q)
+      log_gamma_q_over_2 <- calculate_log_gamma_q_over_2(q)
       log_survives[j] <- -(phi[j]/scale_factor)^2/2 + (q-1)*log(phi[j]/scale_factor) - (q/2 - 1)*log(2) - log_gamma_q_over_2 - log(scale_factor) -
         stats::dnorm(phi[j], mean=stat, sd=scale_factor, log=TRUE)
     }
@@ -424,7 +424,7 @@ test_clusters_approx <- function(X, k1, k2, iso=TRUE, sig=NULL, SigInv=NULL, ndr
     # Recluster the perturbed data set
     cl_Xphi <- cl_fun(Xphi)
     if(preserve_cl(cl, cl_Xphi, k1, k2)) {
-      log_gamma_q_over_2 = calculate_log_gamma_q_over_2(q)
+      log_gamma_q_over_2 <- calculate_log_gamma_q_over_2(q)
       log_survives <- -(phi[j]/scale_factor)^2/2 + (q-1)*log(phi[j]/scale_factor) - (q/2 - 1)*log(2) - log_gamma_q_over_2 - log(scale_factor) -
         stats::dnorm(phi[j], mean=stat, sd=scale_factor, log=TRUE)
       return(log_survives)

--- a/R/util.R
+++ b/R/util.R
@@ -56,3 +56,85 @@ preserve_cl <- function(cl, cl_phi, k1, k2) {
   k1_in & k2_in
 }
 
+#' Calculates log(gamma(q/2)) without overflowing float regardless of size of q
+#'
+#' @keywords internal
+#' 
+#' @param q number of cols of dataframe
+#' 
+#' @return Returns log(gamma(q/2))
+calculate_log_gamma_q_over_2 <- function(q){
+  if (gamma(q/2) != Inf){
+    return(log(gamma(q/2)))
+  }
+  if (q%%2 == 0){
+    return(calculate_log_gamma_q_even(q))
+  }
+  if (q%%2 == 1){
+    return(calculate_log_gamma_q_odd(q))
+  }
+}
+
+#' Calculates log(gamma(q/2)) if q > 343 (if gamma(q/2) overflows a float) and 
+#' q even.
+#' Takes advantage of log rules (log(a*b) = log(a) + log(b)) and fact 
+#' that q will be positive integer.
+#' Even function calculates log(gamma(q)) by summing values of log(x) 
+#' for(x in 1:((q/2)-1)) 
+#' (because q/2 will be integer and gamma(integer) = (integer-1)!)
+#' 
+#' @keywords internal
+#' 
+#' @param q number of cols of dataframe (must be even)
+#' 
+#' @return Returns log(gamma(q/2))
+calculate_log_gamma_q_even <- function(q){
+  if (q%%2 != 0){
+    stop("calculate_log_gamma_q_even can only take even values of q")
+  }
+  n = (q/2)
+  # calculate log(n-1!)
+  n_minus_one_factorial_nums_to_sum = c()
+  for(x in 1:(n-1)){
+    n_minus_one_factorial_nums_to_sum = c(n_minus_one_factorial_nums_to_sum, log(x))
+  }
+  log_n_minus_one_factorial = sum(n_minus_one_factorial_nums_to_sum)
+  return(log_n_minus_one_factorial)
+}
+
+#' Calculates log(gamma(q/2)) if q > 343 (if gamma(q/2) overflows a float) and 
+#' q odd
+#' Takes advantage of log rules (log(a*b) = log(a) + log(b)), 
+#' (log(a/b) = log(a) - log(b)), and fact that q will be positive integer.
+#' 
+#' @keywords internal
+#' 
+#' @param q number of cols of dataframe (must be odd)
+#' 
+#' @return Returns log(gamma(q/2))
+calculate_log_gamma_q_odd <- function(q){
+  if (q%%2 != 1){
+    stop("calculate_log_gamma_q_odd can only take odd values of q")
+  }
+  n = ((q/2) - .5)
+  # calculate log((2n)! * sqrt(pi)), or equivalently log(2n!) + log(sqrt(pi))
+  two_n_factorial_nums_to_sum = c()
+  for(x in 1:(2*n)){
+    two_n_factorial_nums_to_sum = c(two_n_factorial_nums_to_sum, log(x))
+  }
+  log_two_n_factorial = sum(two_n_factorial_nums_to_sum)
+  log_two_n_factorial_plus_log_sqrt_pi = log_two_n_factorial + log(sqrt(pi))
+  
+  # calculate log((4^n) * n!), or equivalently log(4^n) + log(n!)
+  log_four_to_power_of_n = log(4) * n
+  n_factorial_nums_to_sum = c()
+  for(x in 1:n){
+    n_factorial_nums_to_sum = c(n_factorial_nums_to_sum, log(x))
+  }
+  log_n_factorial = sum(n_factorial_nums_to_sum)
+  log_four_to_power_of_n_plus_log_n_factorial = log_four_to_power_of_n + log_n_factorial
+  
+  # subtract first term (numerator) from second term (denominator)
+  return(log_two_n_factorial_plus_log_sqrt_pi-log_four_to_power_of_n_plus_log_n_factorial)
+}
+  

--- a/R/util.R
+++ b/R/util.R
@@ -44,12 +44,12 @@ same_cl <- function(cl1, cl2, K) {
 #'
 #' @param cl clustering of x
 #' @param cl_phi clustering of x'(phi)
-#' @param k1,k2 index of clusters involved in the test 
+#' @param k1,k2 index of clusters involved in the test
 #'
-#' @return Returns TRUE if Ck, Ck' in C(x'(phi)), and FALSE otherwise 
+#' @return Returns TRUE if Ck, Ck' in C(x'(phi)), and FALSE otherwise
 preserve_cl <- function(cl, cl_phi, k1, k2) {
   tab <- table(cl, cl_phi)
-  
+
   k1_in <- (sum(tab[k1, ] != 0) == 1) & (sum(tab[, k1] != 0) == 1)
   k2_in <- (sum(tab[k2, ] != 0) == 1) & (sum(tab[, k2] != 0) == 1)
 
@@ -59,82 +59,82 @@ preserve_cl <- function(cl, cl_phi, k1, k2) {
 #' Calculates log(gamma(q/2)) without overflowing float regardless of size of q
 #'
 #' @keywords internal
-#' 
+#'
 #' @param q number of cols of dataframe
-#' 
+#'
 #' @return Returns log(gamma(q/2))
-calculate_log_gamma_q_over_2 <- function(q){
-  if (gamma(q/2) != Inf){
-    return(log(gamma(q/2)))
+calculate_log_gamma_q_over_2 <- function(q) {
+  if (gamma(q / 2) != Inf) {
+    return(log(gamma(q / 2)))
   }
-  if (q%%2 == 0){
+  if (q %% 2 == 0) {
     return(calculate_log_gamma_q_even(q))
   }
-  if (q%%2 == 1){
+  if (q %% 2 == 1) {
     return(calculate_log_gamma_q_odd(q))
   }
 }
 
-#' Calculates log(gamma(q/2)) if q > 343 (if gamma(q/2) overflows a float) and 
+#' Calculates log(gamma(q/2)) if q > 343 (if gamma(q/2) overflows a float) and
 #' q even.
-#' Takes advantage of log rules (log(a*b) = log(a) + log(b)) and fact 
+#' Takes advantage of log rules (log(a*b) = log(a) + log(b)) and fact
 #' that q will be positive integer.
-#' Even function calculates log(gamma(q)) by summing values of log(x) 
-#' for(x in 1:((q/2)-1)) 
+#' Even function calculates log(gamma(q)) by summing values of log(x)
+#' for(x in 1:((q/2)-1))
 #' (because q/2 will be integer and gamma(integer) = (integer-1)!)
-#' 
+#'
 #' @keywords internal
-#' 
+#'
 #' @param q number of cols of dataframe (must be even)
-#' 
+#'
 #' @return Returns log(gamma(q/2))
-calculate_log_gamma_q_even <- function(q){
-  if (q%%2 != 0){
+calculate_log_gamma_q_even <- function(q) {
+  if (q %% 2 != 0) {
     stop("calculate_log_gamma_q_even can only take even values of q")
   }
-  n = (q/2)
+  n <- (q / 2)
   # calculate log(n-1!)
-  n_minus_one_factorial_nums_to_sum = c()
-  for(x in 1:(n-1)){
-    n_minus_one_factorial_nums_to_sum = c(n_minus_one_factorial_nums_to_sum, log(x))
+  n_minus_one_fact_nums_to_sum <- c()
+  for (x in 1:(n - 1)) {
+    n_minus_one_factl_nums_to_sum <- c(n_minus_one_factl_nums_to_sum, log(x))
   }
-  log_n_minus_one_factorial = sum(n_minus_one_factorial_nums_to_sum)
-  return(log_n_minus_one_factorial)
+  log_n_minus_one_fact <- sum(n_minus_one_fact_nums_to_sum)
+  return(log_n_minus_one_fact)
 }
 
-#' Calculates log(gamma(q/2)) if q > 343 (if gamma(q/2) overflows a float) and 
+#' Calculates log(gamma(q/2)) if q > 343 (if gamma(q/2) overflows a float) and
 #' q odd
-#' Takes advantage of log rules (log(a*b) = log(a) + log(b)), 
+#' Takes advantage of log rules (log(a*b) = log(a) + log(b)),
 #' (log(a/b) = log(a) - log(b)), and fact that q will be positive integer.
-#' 
+#'
 #' @keywords internal
-#' 
+#'
 #' @param q number of cols of dataframe (must be odd)
-#' 
+#'
 #' @return Returns log(gamma(q/2))
-calculate_log_gamma_q_odd <- function(q){
-  if (q%%2 != 1){
+calculate_log_gamma_q_odd <- function(q) {
+  if (q %% 2 != 1) {
     stop("calculate_log_gamma_q_odd can only take odd values of q")
   }
-  n = ((q/2) - .5)
+  n <- ((q / 2) - .5)
+
   # calculate log((2n)! * sqrt(pi)), or equivalently log(2n!) + log(sqrt(pi))
-  two_n_factorial_nums_to_sum = c()
-  for(x in 1:(2*n)){
-    two_n_factorial_nums_to_sum = c(two_n_factorial_nums_to_sum, log(x))
+  two_n_factorial_nums_to_sum <- c()
+  for (x in 1:(2 * n)) {
+    two_n_factorial_nums_to_sum <- c(two_n_factorial_nums_to_sum, log(x))
   }
-  log_two_n_factorial = sum(two_n_factorial_nums_to_sum)
-  log_two_n_factorial_plus_log_sqrt_pi = log_two_n_factorial + log(sqrt(pi))
-  
+  log_two_n_factorial <- sum(two_n_factorial_nums_to_sum)
+  log_two_n_fact_sqrt_pi <- log_two_n_factorial + log(sqrt(pi))
+
   # calculate log((4^n) * n!), or equivalently log(4^n) + log(n!)
-  log_four_to_power_of_n = log(4) * n
-  n_factorial_nums_to_sum = c()
-  for(x in 1:n){
-    n_factorial_nums_to_sum = c(n_factorial_nums_to_sum, log(x))
+  log_four_to_power_of_n <- log(4) * n
+  n_factorial_nums_to_sum <- c()
+  for (x in 1:n) {
+    n_factorial_nums_to_sum <- c(n_factorial_nums_to_sum, log(x))
   }
-  log_n_factorial = sum(n_factorial_nums_to_sum)
-  log_four_to_power_of_n_plus_log_n_factorial = log_four_to_power_of_n + log_n_factorial
-  
+  log_n_factorial <- sum(n_factorial_nums_to_sum)
+  log_four_to_n_n_factorial <- log_four_to_power_of_n + log_n_factorial
+
   # subtract first term (numerator) from second term (denominator)
-  return(log_two_n_factorial_plus_log_sqrt_pi-log_four_to_power_of_n_plus_log_n_factorial)
+  return(log_two_n_fact_sqrt_pi - log_four_to_n_n_factorial)
 }
-  

--- a/README.md
+++ b/README.md
@@ -10,13 +10,3 @@ Make sure that ``devtools`` is installed by running ``install.packages("devtools
 ```R
 devtools::install_github("lucylgao/clusterpval")
 ```
-
-## Forking to try to prevent float overflow in test_complete_hier_clusters_approx and test_clusters_approx
-```R
-> i = 1
-> while (gamma(i/2) != Inf) {i = i + 1}
-> i
-[1] 344
-```
-
-Any dataset with more than 343 cols will have a log_survives of -Infinity for every perturbed dataset, and NaN values for pval and stderr. I propose writing a function that does the log and the gamma at the same time to avoid overflowing a float.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Make sure that ``devtools`` is installed by running ``install.packages("devtools
 devtools::install_github("lucylgao/clusterpval")
 ```
 
-## Forking to try to prevent float overflow
+## Forking to try to prevent float overflow in test_complete_hier_clusters_approx and test_clusters_approx
 ```R
 > i = 1
 > while (gamma(i/2) != Inf) {i = i + 1}

--- a/README.md
+++ b/README.md
@@ -11,3 +11,12 @@ Make sure that ``devtools`` is installed by running ``install.packages("devtools
 devtools::install_github("lucylgao/clusterpval")
 ```
 
+## Forking to try to prevent float overflow
+```R
+> i = 1
+> while (gamma(i/2) != Inf) {i = i + 1}
+> i
+[1] 344
+```
+
+Any dataset with more than 343 cols will have a log_survives of -Infinity for every perturbed dataset, and NaN values for pval and stderr. I propose writing a function that does the log and the gamma at the same time to avoid overflowing a float.


### PR DESCRIPTION
Addresses issue described in https://github.com/lucylgao/clusterpval/issues/8. Adds helper functions to util.R that use log rules and the formulas for calculating gamma(x) when x is a positive integer or positive half integer to calculate `log(gamma(q/2))` without overflowing a float.